### PR TITLE
Check for basename to not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.DS_Store
+.idea

--- a/BlueImp/UploadHandler.php
+++ b/BlueImp/UploadHandler.php
@@ -296,7 +296,7 @@ class UploadHandler
     }
 
     /**
-     * Returns an array with the dotted allowed extensions plus no extension. e.g. ['.jpeg', '.png', '']
+     * Returns an array with the dotted allowed extensions. e.g. ['.jpeg', '.png']
      *
      * @param string $acceptedFileTypesRegex
      * @return array
@@ -305,7 +305,6 @@ class UploadHandler
     {
         preg_match_all('(\.[a-z]+)', $acceptedFileTypesRegex, $matches);
         $extensions = $matches[0];
-        $extensions[] = '';
 
         return $extensions;
     }

--- a/BlueImp/UploadHandler.php
+++ b/BlueImp/UploadHandler.php
@@ -266,11 +266,33 @@ class UploadHandler
             $file_name .= '.'.$matches[1];
         }
         if ($this->options['discard_aborted_uploads']) {
-            while(is_file($this->options['upload_dir'].$file_name)) {
+            while($this->is_basename_existing($this->options['upload_dir'], $file_name)) {
                 $file_name = $this->upcount_name($file_name);
             }
         }
         return $file_name;
+    }
+
+    protected function is_basename_existing($dir, $fileName)
+    {
+        $extensions = $this->get_accepted_extensions_from_options_regex($this->options['accept_file_types']);
+        $pathParts = pathinfo($fileName);
+        $nameWithoutExtension = $pathParts['filename'];
+        foreach ($extensions as $extension) {
+            if (is_file($dir . $nameWithoutExtension . $extension)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function get_accepted_extensions_from_options_regex($regex)
+    {
+        preg_match_all('(\.[a-z]+)', $regex, $matches);
+        $extensions = $matches[0];
+        $extensions[] = '';
+
+        return $extensions;
     }
 
     protected function handle_form_data($file, $index) {

--- a/BlueImp/UploadHandler.php
+++ b/BlueImp/UploadHandler.php
@@ -274,6 +274,14 @@ class UploadHandler
         return $file_name;
     }
 
+    /**
+     * Returns true if a file with the same basename exists in the directory for any of the allowed file types.
+     *
+     * @param string $dir
+     * @param string $fileName
+     * @param string $acceptedFileTypesRegex
+     * @return bool
+     */
     protected function is_basename_existing($dir, $fileName, $acceptedFileTypesRegex)
     {
         $extensions = $this->get_accepted_extensions_from_options_regex($acceptedFileTypesRegex);
@@ -287,6 +295,12 @@ class UploadHandler
         return false;
     }
 
+    /**
+     * Returns an array with the dotted allowed extensions plus no extension. e.g. ['.jpeg', '.png', '']
+     *
+     * @param string $acceptedFileTypesRegex
+     * @return array
+     */
     protected function get_accepted_extensions_from_options_regex($acceptedFileTypesRegex)
     {
         preg_match_all('(\.[a-z]+)', $acceptedFileTypesRegex, $matches);

--- a/BlueImp/UploadHandler.php
+++ b/BlueImp/UploadHandler.php
@@ -265,17 +265,18 @@ class UploadHandler
             preg_match('/^image\/(gif|jpe?g|png)/', $type, $matches)) {
             $file_name .= '.'.$matches[1];
         }
+        $acceptedFileTypesRegex = $this->options['accept_file_types'];
         if ($this->options['discard_aborted_uploads']) {
-            while($this->is_basename_existing($this->options['upload_dir'], $file_name)) {
+            while($this->is_basename_existing($this->options['upload_dir'], $file_name, $acceptedFileTypesRegex)) {
                 $file_name = $this->upcount_name($file_name);
             }
         }
         return $file_name;
     }
 
-    protected function is_basename_existing($dir, $fileName)
+    protected function is_basename_existing($dir, $fileName, $acceptedFileTypesRegex)
     {
-        $extensions = $this->get_accepted_extensions_from_options_regex($this->options['accept_file_types']);
+        $extensions = $this->get_accepted_extensions_from_options_regex($acceptedFileTypesRegex);
         $pathParts = pathinfo($fileName);
         $nameWithoutExtension = $pathParts['filename'];
         foreach ($extensions as $extension) {
@@ -286,9 +287,9 @@ class UploadHandler
         return false;
     }
 
-    protected function get_accepted_extensions_from_options_regex($regex)
+    protected function get_accepted_extensions_from_options_regex($acceptedFileTypesRegex)
     {
-        preg_match_all('(\.[a-z]+)', $regex, $matches);
+        preg_match_all('(\.[a-z]+)', $acceptedFileTypesRegex, $matches);
         $extensions = $matches[0];
         $extensions[] = '';
 

--- a/Test/BlueImp/UploadHandlerTest.php
+++ b/Test/BlueImp/UploadHandlerTest.php
@@ -44,6 +44,10 @@ class UploadHandlerTest extends \PHPUnit_Framework_TestCase
 
         $result = $uploadHandler->is_basename_existing_wrapper($dir, 'I-do-not-exist.jpg', $regex);
         $this->assertFalse($result);
+
+        $regex = '/(\.pdf)$/i';
+        $result = $uploadHandler->is_basename_existing_wrapper($dir, 'test.jpg', $regex);
+        $this->assertFalse($result);
     }
 
     /**

--- a/Test/BlueImp/UploadHandlerTest.php
+++ b/Test/BlueImp/UploadHandlerTest.php
@@ -16,6 +16,24 @@ class UploadHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      *
      */
+    public function testGetExtensionsFromRegex()
+    {
+        $regex = '/(\.jpg|\.jpeg|\.gif|\.png|\.pdf)$/i';
+        $uploadHandler = new UploadHandlerMock();
+        $extensions = $uploadHandler->get_accepted_extensions_from_options_regex_wrapper($regex);
+
+        $this->assertCount(6, $extensions);
+        $this->assertEquals('.jpg', $extensions[0]);
+        $this->assertEquals('.jpeg', $extensions[1]);
+        $this->assertEquals('.gif', $extensions[2]);
+        $this->assertEquals('.png', $extensions[3]);
+        $this->assertEquals('.pdf', $extensions[4]);
+        $this->assertEquals('', $extensions[5]);
+    }
+
+    /**
+     *
+     */
     public function testUploadHandlerWithUmlauts()
     {
         $uploadHandler = new UploadHandlerMock();
@@ -40,6 +58,16 @@ class UploadHandlerMock extends UploadHandler
      */
     public function __construct(){
 
+    }
+
+    public function get_accepted_extensions_from_options_regex_wrapper($regex)
+    {
+        return $this->get_accepted_extensions_from_options_regex($regex);
+    }
+
+    public function is_basename_existing_wrapper()
+    {
+        return $this->is_basename_existing();
     }
 }
 

--- a/Test/BlueImp/UploadHandlerTest.php
+++ b/Test/BlueImp/UploadHandlerTest.php
@@ -21,13 +21,17 @@ class UploadHandlerTest extends \PHPUnit_Framework_TestCase
         $uploadHandler = new UploadHandlerMock();
         $extensions = $uploadHandler->get_accepted_extensions_from_options_regex_wrapper($regex);
 
-        $this->assertCount(6, $extensions);
+        $this->assertCount(5, $extensions);
         $this->assertEquals('.jpg', $extensions[0]);
         $this->assertEquals('.jpeg', $extensions[1]);
         $this->assertEquals('.gif', $extensions[2]);
         $this->assertEquals('.png', $extensions[3]);
         $this->assertEquals('.pdf', $extensions[4]);
-        $this->assertEquals('', $extensions[5]);
+
+        $regex = '/()$/i';
+        $extensions = $uploadHandler->get_accepted_extensions_from_options_regex_wrapper($regex);
+        $this->assertCount(0, $extensions);
+
     }
 
     /**
@@ -46,6 +50,10 @@ class UploadHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($result);
 
         $regex = '/(\.pdf)$/i';
+        $result = $uploadHandler->is_basename_existing_wrapper($dir, 'test.jpg', $regex);
+        $this->assertFalse($result);
+
+        $regex = '/()$/i';
         $result = $uploadHandler->is_basename_existing_wrapper($dir, 'test.jpg', $regex);
         $this->assertFalse($result);
     }

--- a/Test/BlueImp/UploadHandlerTest.php
+++ b/Test/BlueImp/UploadHandlerTest.php
@@ -12,7 +12,6 @@ use PunkAve\FileUploaderBundle\BlueImp\UploadHandler;
  */
 class UploadHandlerTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      *
      */
@@ -29,6 +28,22 @@ class UploadHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('.png', $extensions[3]);
         $this->assertEquals('.pdf', $extensions[4]);
         $this->assertEquals('', $extensions[5]);
+    }
+
+    /**
+     *
+     */
+    public function testIsBasenameExisting()
+    {
+        $regex = '/(\.jpg|\.jpeg|\.gif|\.png|\.pdf)$/i';
+        $dir = __DIR__ . '/../upload-dir/';
+        $uploadHandler = new UploadHandlerMock();
+
+        $result = $uploadHandler->is_basename_existing_wrapper($dir, 'test.png', $regex);
+        $this->assertTrue($result);
+
+        $result = $uploadHandler->is_basename_existing_wrapper($dir, 'I-do-not-exist.jpg', $regex);
+        $this->assertFalse($result);
     }
 
     /**
@@ -65,9 +80,9 @@ class UploadHandlerMock extends UploadHandler
         return $this->get_accepted_extensions_from_options_regex($regex);
     }
 
-    public function is_basename_existing_wrapper()
+    public function is_basename_existing_wrapper($directory, $filename, $regex)
     {
-        return $this->is_basename_existing();
+        return $this->is_basename_existing($directory, $filename, $regex);
     }
 }
 


### PR DESCRIPTION
in general: I used underscore method naming to be consistent with the bundle